### PR TITLE
Prevent dual package hazard in webpack5

### DIFF
--- a/packages/next-plugin-preact/index.js
+++ b/packages/next-plugin-preact/index.js
@@ -20,6 +20,17 @@ module.exports = function withPreact(nextConfig = {}) {
       webpack(config, options) {
         const { dev, isServer, defaultLoaders } = options;
 
+        // Disable package exports field resolution in webpack. It can lead
+        // to dual package hazards where packages are imported twice: One
+        // commonjs version and one ESM version. This breaks hooks which have
+        // to rely on a singleton by design (nothing we can do about that).
+        // See #25 and https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_dual_package_hazard
+        // for more information.
+        const webpackVersion = options.webpack.version;
+        if (+webpackVersion.split('.')[0] >= 5) {
+          config.resolve.exportsFields = [];
+        }
+
         if (!defaultLoaders) {
           throw new Error(
             'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'

--- a/packages/next-plugin-preact/index.js
+++ b/packages/next-plugin-preact/index.js
@@ -27,7 +27,7 @@ module.exports = function withPreact(nextConfig = {}) {
         // See #25 and https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_dual_package_hazard
         // for more information.
         const webpackVersion = options.webpack.version;
-        if (+webpackVersion.split('.')[0] >= 5) {
+        if (isServer && +webpackVersion.split('.')[0] >= 5) {
           config.resolve.exportsFields = [];
         }
 


### PR DESCRIPTION
Disable package exports field resolution in webpack. It can lead to dual package hazards where packages are imported twice: One `commonjs` version and one `ESM` version. This breaks hooks which have to rely on a singleton by design (nothing we can do about that).

There is an official section about that in [the node documentation](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_dual_package_hazard).

Resolves the part of #25 where hooks were failing. 