### PR TITLE
chore: Bump @prefresh/webpack to 3.3.2

### DIFF
--- a/packages/next-plugin-preact/package.json
+++ b/packages/next-plugin-preact/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {},
   "dependencies": {
     "@prefresh/next": "^1.4.6",
-    "@prefresh/webpack": "^3.3.0",
+    "@prefresh/webpack": "^3.3.2",
     "module-alias": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
It has been mentioned in https://github.com/preactjs/next-plugin-preact/issues/34 that the bugfixes @JoviDeCroock thankfully did aren't picked up yet. I've reinstalled the whole project today, but it still gives me:

```
│ ├─┬ @prefresh/next@1.4.6
│ │ ├── @prefresh/babel-plugin@0.4.1
│ │ ├── @prefresh/core@1.3.2
│ │ ├── @prefresh/utils@1.1.1
│ │ ├── @prefresh/webpack@3.3.0 deduped
│ ├─┬ @prefresh/webpack@3.3.0
│ │ ├── @prefresh/core@1.3.2 deduped
│ │ └── @prefresh/utils@1.1.1 deduped
```

instead of 3.3.2. I guess this should be followed by a patch release? 